### PR TITLE
Markdown improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,25 @@ Some _very_ basic [**Jest**](https://jestjs.io/) unit cases were added for some 
 
 ## remark-plugins
 
-For inputs that accept **markdown** (e.g. prayer items, notes), the application leverages the `@uiw/react-md-editor` library, which accepts **Remark** plugins that can further enhance the way MD is converted to HTML. This library provides a set of these plugins for special cases of use to Christians.
+For inputs that accept **markdown** (e.g. prayer items, notes), the application leverages the `@uiw/react-md-editor` library, which supports most common markdown conventions (e.g. bold and italics, headings, inline code and codeblocks, blockquotes, links, and even footnotes).
+
+The MD editor used also supports **Remark plugins** that can further enhance the way MD is converted to HTML. This library provides a set of specialized plugins of use to Christians. These plugins make it easier to use common Christian notations with nicely rendered outputs. For example:
+
+```markdown
+Sometime around 1446^^B.C.^^ God said to Moses in [[Ex 3:14]ESV]:
+
+> ^-^I am who I am^-^
+
+or, as rendered in the King James Version[^1],
+
+> ^^^I AM THAT I AM^^^
+
+This comment from the 15^th^ Century was echoed in ==Jesus' many "I am" statements== in the New Testament.
+
+[^1]: [[Ex 3:14]KJV]
+```
+
+These notations aren't necessary to use the markdown features of the site, but add some extra help when necessary.
 
 ### Title All Caps (`tac`)
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ Along with ignoring the `dsDB.json` file, the `.gitignore` file will also ignore
 
 A library with common code leveraged across the other applications. It exposes commonly used type definitions that are returned from APIs but also used in the UI app, some error handling code that is used by both of the APIs, and anything else that could be refactored out so that the same code wasn't being written multiple times.
 
-## remark-plugins
-
-For inputs that accept **markdown**, the application leverages the `@uiw/react-md-editor` library, which accepts **Remark** plugins that can further enhance the way MD is converted to HTML. This library provides a set of these plugins, to provide some specialized use cases.
-
 ### Bible Reference/OSIS Parsing
 
 Part of the common functionality is a set of functions for parsing and working with Bible passage references. It can:
@@ -71,6 +67,84 @@ To clear up some of what was just described, here's some commonly used terminolo
 This library makes heavy use of the [**Bible Passage Reference Parser**](https://github.com/openbibleinfo/Bible-Passage-Reference-Parser) and [**Bible Reference Formatter**](https://github.com/openbibleinfo/Bible-Reference-Formatter) libraries. In fact, a number of these functions are just light wrappers over those underlying libraries, which do the heavy lifting. Helper functions like `isPassageRefValid()` (returning a simple Boolean as opposed to a complicated object or OSIS string that need to be parsed) are easier to use in the wireframe.
 
 Some _very_ basic [**Jest**](https://jestjs.io/) unit cases were added for some of the functions, but only where it was deemed to be a time saver.
+
+## remark-plugins
+
+For inputs that accept **markdown** (e.g. prayer items, notes), the application leverages the `@uiw/react-md-editor` library, which accepts **Remark** plugins that can further enhance the way MD is converted to HTML. This library provides a set of these plugins for special cases of use to Christians.
+
+### Title All Caps (`tac`)
+
+Handles a special case that comes up often in Christian writing where a word should be written in all capital letters but can be rendered in Small Caps (where the device supports it). A common example is the way the word "LORD" is often rendered in Old Testament Scriptures.
+
+For example, the following could be written in markdown:
+
+```markdown
+Thus saith the ^^^LORD^^^.
+```
+
+The text surrounded with `^^^` will be replaced with spans supporting CSS attributes such as the following (without the spaces between the spans):
+
+```html
+<span style="text-transform: uppercase;">L</span>
+<span style="text-transform: lowercase; font-variant: small-caps;">ORD</span>
+```
+
+On browsers that support these CSS features, this will be rendered in small caps, with the "L" larger than the "ORD." On browsers that _don't_ support the latest CSS markup, the text will be rendered in all uppercase as "LORD", which is a good fallback. (The Small Caps can't be demonstrated properly on this page, since standard markdown doesn't support it.)
+
+### Lower Caps (`lowerCaps`)
+
+Similar to Title All Caps in that the text is rendered as Small Caps except that all of the letters are in small letters. Useful for writing things like `2022A.D.` where the "A.D." should be rendered smaller for readability.
+
+```markdown
+In the year 2022^^A.D.^^
+```
+
+Just as with "Title All Caps", this approach allows the letters to be written in all capitals, rendered in all capitals as a fall-back, and rendered as smaller caps (for readability) on devices that support the advanced CSS markup.
+
+### Small Caps (`smallCaps`)
+
+Simply renders text surrounded with `^-^` as regular Small Caps.
+
+```markdown
+Some of this text will be ^-^Small Caps^-^ on devices that support it.
+```
+
+Again, this can't be properly demonstrated in this GitHub markdown, but it's just rendered as a `<span>` with the `font-variant ` set to `small-caps`.
+
+### Highlight (`highlight`)
+
+Highlights text surrounded by `==` (using the HTML `<mark>`) tag. Once again this can't be demonstrated, but
+
+```markdown
+Some ==highlighted text==
+```
+
+will be rendered to the underlying HTML as
+
+```html
+Some <mark>highlighted text</mark>
+```
+
+such that "highlighted text" is highlighted in yellow.
+
+### Bible Links (`bibleLinks`)
+
+Special case for rendering a link to a Bible passage on the **Bible Gateway** website, The link will also be decorated with the version in parentheses as well as a cross icon to visually distinguish these links from other links.
+
+```markdown
+Link to [[Rom 1:1]ESV]
+```
+
+would render HTML as follows:
+
+```html
+Link to
+<a href="https://www.biblegateway.com/passage/?search=Romans%201%3A1&amp;version=ESV" target="_blank"
+  >Romans 1:1 (ESV)✞</a
+>
+```
+
+If no version is specified (such as `[[Rom 1:1]]` instead of `[[Rom 1:1]NIV]`) the default version selected in the user's preferences will be used.
 
 # Common Commands
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Link to
 >
 ```
 
-If no version is specified (such as `[[Rom 1:1]]` instead of `[[Rom 1:1]NIV]`) the default version selected in the user's preferences will be used.
+If no version is specified (such as `[[Rom 1:1]]` instead of `[[Rom 1:1]NIV]`) it defaults to ESV.
 
 # Common Commands
 

--- a/README.md
+++ b/README.md
@@ -110,36 +110,6 @@ npm run build
 
 It's best to shut down the application(s) (if running), run the build, and then reload VS Code to get the latest changes.
 
-### Run a Build of remark-plugins
-
-There are issues getting the **remark-plugins** library to build; the build sometimes hangs when changes are made. There is likely a misconfiguration somewhere in a `tsconfig` or other file.
-
-In order to get **remark-plugins** to build, it has to be built individually; assuming the developer is starting from the root directory, they would need to:
-
-```bash
-# attempting to run the build will hang; this doesn't work:
-npm run build
-
-# go to the directory of the library
-cd packages/remark-plugins
-
-# deleting the build folder seems to help
-rm -r -f build/
-
-# run the build only for this library
-npm run build
-```
-
-After this, builds can be run normally again:
-
-```bash
-# go back to root
-cd ../..
-
-# running the build normally works now!
-npm run build
-```
-
 ## Git Branching
 
 This might be unprofessional but the original author kept Googling some commonly used Git commands over and over, and figured it would be easier to just write them here. These are the most commonly used Git commands, including some that are _so_ common that everyone knows them instinctively but they're included for completeness.

--- a/apps/ds-api/package.json
+++ b/apps/ds-api/package.json
@@ -26,6 +26,6 @@
     "@types/node": "^17.0.5",
     "@types/uuid": "^8.3.3",
     "ts-node-dev": "^1.1.8",
-    "typescript": "^4.5.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/apps/ds-ui/package.json
+++ b/apps/ds-ui/package.json
@@ -23,7 +23,7 @@
     "recharts": "^2.1.10",
     "remark-supersub": "^1.0.0",
     "sass": "^1.52.1",
-    "typescript": "^4.5.4",
+    "typescript": "^4.7.4",
     "yup": "^0.32.11"
   },
   "scripts": {

--- a/apps/ds-ui/src/components/common/MarkdownBox.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownBox.tsx
@@ -2,10 +2,10 @@ import React, { useState, useRef, useEffect } from 'react';
 import MDEditor, { ICommand, TextState, TextAreaTextApi } from '@uiw/react-md-editor';
 import { Button } from 'react-bootstrap';
 import supersub from 'remark-supersub';
-import { tac, lowerCaps, smallCaps, highlight } from '@devouringscripture/remark-plugins';
+import { tac, lowerCaps, smallCaps, highlight, bibleLinks } from '@devouringscripture/remark-plugins';
 import { MarkdownTutorial } from './MarkdownTutorial';
 
-const MIN_SIZE_FOR_TOOLBAR = 350;
+const MIN_SIZE_FOR_TOOLBAR = 450;
 
 interface IMarkdownPreview {
   content: string;
@@ -17,7 +17,7 @@ export const MarkdownPreview = ({ content, shaded = true }: IMarkdownPreview) =>
     <MDEditor.Markdown
       source={content}
       className={classNames}
-      remarkPlugins={[tac, lowerCaps, smallCaps, highlight, supersub]}
+      remarkPlugins={[tac, lowerCaps, smallCaps, highlight, supersub, bibleLinks]}
     />
   );
 };
@@ -81,7 +81,29 @@ const highlightCommand: ICommand = {
   },
 };
 
-const commandsToFilterOut = ['code', 'image', 'checked-list'];
+const esvLinkCommand: ICommand = {
+  name: 'BibleLink',
+  keyCommand: 'BibleLink',
+  buttonProps: { 'aria-label': 'Bible link' },
+  icon: <u>ESV✞</u>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `[[${state.selectedText}]ESV]`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+const nivLinkCommand: ICommand = {
+  name: 'BibleLink',
+  keyCommand: 'BibleLink',
+  buttonProps: { 'aria-label': 'Bible link' },
+  icon: <u>NIV✞</u>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `[[${state.selectedText}]NIV]`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+const commandsToFilterOut = ['code', 'image', 'checked-list', 'hr', 'title2'];
 
 const commandsFilter = (command: ICommand<string>, isExtra: boolean) => {
   if (isExtra) {
@@ -147,7 +169,15 @@ export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IM
           highlightEnable={true}
           preview="edit"
           defaultTabEnable={true}
-          extraCommands={[lordCommand, scCommand, scstyleCommand, superCommand, highlightCommand]}
+          extraCommands={[
+            lordCommand,
+            scCommand,
+            scstyleCommand,
+            esvLinkCommand,
+            nivLinkCommand,
+            superCommand,
+            highlightCommand,
+          ]}
           visiableDragbar={false}
           commandsFilter={commandsFilter}
           hideToolbar={!showToolbar}

--- a/apps/ds-ui/src/components/common/MarkdownBox.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownBox.tsx
@@ -87,8 +87,8 @@ const highlightCommand: ICommand = {
 };
 
 const esvLinkCommand: ICommand = {
-  name: 'BibleLink',
-  keyCommand: 'BibleLink',
+  name: 'ESVLink',
+  keyCommand: 'ESVLink',
   buttonProps: { 'aria-label': 'Bible link' },
   icon: <u>ESV✞</u>,
   execute: (state: TextState, api: TextAreaTextApi) => {
@@ -98,8 +98,8 @@ const esvLinkCommand: ICommand = {
 };
 
 const nivLinkCommand: ICommand = {
-  name: 'BibleLink',
-  keyCommand: 'BibleLink',
+  name: 'NIVLink',
+  keyCommand: 'NIVLink',
   buttonProps: { 'aria-label': 'Bible link' },
   icon: <u>NIV✞</u>,
   execute: (state: TextState, api: TextAreaTextApi) => {
@@ -108,6 +108,16 @@ const nivLinkCommand: ICommand = {
   },
 };
 
+const bibleLinkCommand: ICommand = {
+  name: 'BibleLink',
+  keyCommand: 'BibleLink',
+  buttonProps: { 'aria-label': 'Bible link' },
+  icon: <u>BG✞</u>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `[[${state.selectedText}]]`;
+    api.replaceSelection(modifyText);
+  },
+};
 const commandsToFilterOut = ['code', 'image', 'checked-list', 'hr', 'title2'];
 
 const commandsFilter = (command: ICommand<string>, isExtra: boolean) => {
@@ -180,6 +190,7 @@ export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IM
             scstyleCommand,
             esvLinkCommand,
             nivLinkCommand,
+            bibleLinkCommand,
             superCommand,
             highlightCommand,
           ]}

--- a/apps/ds-ui/src/components/common/MarkdownBox.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownBox.tsx
@@ -26,7 +26,12 @@ const lordCommand: ICommand = {
   name: 'LORD',
   keyCommand: 'LORD',
   buttonProps: { 'aria-label': 'Insert LORD' },
-  icon: <b className="sc">LORD</b>,
+  icon: (
+    <>
+      <b>L</b>
+      <b style={{ fontVariant: 'small-caps' }}>ord</b>
+    </>
+  ),
   execute: (state: TextState, api: TextAreaTextApi) => {
     const modifyText = `^^^${state.selectedText ? state.selectedText : 'LORD'}^^^`;
     api.replaceSelection(modifyText);

--- a/apps/ds-ui/src/components/common/MarkdownBox.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownBox.tsx
@@ -48,7 +48,7 @@ const scstyleCommand: ICommand = {
   name: 'SmallCaps',
   keyCommand: 'SmallCaps',
   buttonProps: { 'aria-label': 'Insert Small Caps' },
-  icon: <span className="small-caps-style">SmCa</span>,
+  icon: <span style={{ fontVariant: 'small-caps' }}>SmCa</span>,
   execute: (state: TextState, api: TextAreaTextApi) => {
     const modifyText = `^-^${state.selectedText}^-^`;
     api.replaceSelection(modifyText);

--- a/apps/ds-ui/src/components/common/MarkdownBox.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownBox.tsx
@@ -37,7 +37,7 @@ const scCommand: ICommand = {
   name: 'SC',
   keyCommand: 'SC',
   buttonProps: { 'aria-label': 'Insert all SMALL CAPS' },
-  icon: <b className="sc2">A.D.</b>,
+  icon: <b style={{ fontVariant: 'small-caps', textTransform: 'lowercase', display: 'inline-block' }}>A.D.</b>,
   execute: (state: TextState, api: TextAreaTextApi) => {
     const modifyText = `^^${state.selectedText ? state.selectedText : 'A.D.'}^^`;
     api.replaceSelection(modifyText);

--- a/apps/ds-ui/src/components/common/MarkdownTutorial.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownTutorial.tsx
@@ -100,8 +100,8 @@ export const MarkdownTutorial = ({ show, handleClose }: IMarkdownTutorial) => {
                 <b className="sc">LORD</b>
               </td>
               <td>
-                Renders text in <span className="small-caps-style">Small Caps</span>, ensuring that the first letter is
-                capitalized, while allowing the original text to stay all Caps.
+                Renders text in <span style={{ fontVariant: 'small-caps' }}>Small Caps</span>, ensuring that the first
+                letter is capitalized, while allowing the original text to stay all Caps.
               </td>
               <td>
                 <code>The ^^^LORD^^^ is one.</code>
@@ -127,14 +127,14 @@ export const MarkdownTutorial = ({ show, handleClose }: IMarkdownTutorial) => {
             </tr>
             <tr>
               <td>
-                <span className="small-caps-style">SmCa</span>
+                <span style={{ fontVariant: 'small-caps' }}>SmCa</span>
               </td>
               <td>Normal Small Caps style</td>
               <td>
                 <code>He is the ^-^I Am^-^</code>
               </td>
               <td className="reading-text">
-                He is the <span className="small-caps-style">I Am</span>
+                He is the <span style={{ fontVariant: 'small-caps' }}>I Am</span>
               </td>
             </tr>
             <tr>

--- a/apps/ds-ui/src/components/common/MarkdownTutorial.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownTutorial.tsx
@@ -97,17 +97,20 @@ export const MarkdownTutorial = ({ show, handleClose }: IMarkdownTutorial) => {
           <tbody>
             <tr>
               <td>
-                <b className="sc">LORD</b>
+                <b>L</b>
+                <b style={{ fontVariant: 'small-caps' }}>ord</b>
               </td>
               <td>
                 Renders text in <span style={{ fontVariant: 'small-caps' }}>Small Caps</span>, ensuring that the first
                 letter is capitalized, while allowing the original text to stay all Caps.
               </td>
               <td>
-                <code>The ^^^LORD^^^ is one.</code>
+                <code>The ^^^LORD^^^ is one. The ^^^GOD ALMIGHTY^^^ is good.</code>
               </td>
               <td className="reading-text">
-                The <span className="sc">LORD</span> is one.
+                The L<span style={{ fontVariant: 'small-caps' }}>ord</span> is one. The G
+                <span style={{ fontVariant: 'small-caps' }}>od</span> A
+                <span style={{ fontVariant: 'small-caps' }}>lmighty</span> is good.
               </td>
             </tr>
             <tr>

--- a/apps/ds-ui/src/components/common/MarkdownTutorial.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownTutorial.tsx
@@ -112,7 +112,9 @@ export const MarkdownTutorial = ({ show, handleClose }: IMarkdownTutorial) => {
             </tr>
             <tr>
               <td>
-                <span className="sc2">A.D.</span>
+                <span style={{ fontVariant: 'small-caps', textTransform: 'lowercase', display: 'inline-block' }}>
+                  A.D.
+                </span>
               </td>
               <td>
                 Renders text in small caps, but none of the letters will be capitalized (even though they're all
@@ -122,7 +124,11 @@ export const MarkdownTutorial = ({ show, handleClose }: IMarkdownTutorial) => {
                 <code>It took place in 30^^A.D.^^.</code>
               </td>
               <td className="reading-text">
-                It took place in 30<span className="sc2">A.D.</span>.
+                It took place in 30
+                <span style={{ fontVariant: 'small-caps', textTransform: 'lowercase', display: 'inline-block' }}>
+                  A.D.
+                </span>
+                .
               </td>
             </tr>
             <tr>

--- a/apps/ds-ui/src/styles/ds-styles.scss
+++ b/apps/ds-ui/src/styles/ds-styles.scss
@@ -52,6 +52,16 @@ body {
   font-family: 'Merriweather', serif;
 }
 
+.biblelink::after {
+  content: '\271E';
+}
+.esvlink::after {
+  content: ' (ESV)\271E';
+}
+.nivlink::after {
+  content: ' (NIV)\271E';
+}
+
 .page-main-container {
   @extend .m-0;
   @extend .p-1;

--- a/apps/ds-ui/src/styles/ds-styles.scss
+++ b/apps/ds-ui/src/styles/ds-styles.scss
@@ -38,12 +38,6 @@ body {
   text-transform: uppercase;
 }
 
-.sc2 {
-  font-variant: small-caps;
-  text-transform: lowercase;
-  display: inline-block;
-}
-
 .reading-text {
   font-family: 'Merriweather', serif;
 }

--- a/apps/ds-ui/src/styles/ds-styles.scss
+++ b/apps/ds-ui/src/styles/ds-styles.scss
@@ -44,10 +44,6 @@ body {
   display: inline-block;
 }
 
-.small-caps-style {
-  font-variant: small-caps;
-}
-
 .reading-text {
   font-family: 'Merriweather', serif;
 }

--- a/apps/ds-ui/src/styles/ds-styles.scss
+++ b/apps/ds-ui/src/styles/ds-styles.scss
@@ -32,16 +32,6 @@ body {
   font-family: 'Merriweather', serif;
 }
 
-.biblelink::after {
-  content: '\271E';
-}
-.esvlink::after {
-  content: ' (ESV)\271E';
-}
-.nivlink::after {
-  content: ' (NIV)\271E';
-}
-
 .page-main-container {
   @extend .m-0;
   @extend .p-1;

--- a/apps/ds-ui/src/styles/ds-styles.scss
+++ b/apps/ds-ui/src/styles/ds-styles.scss
@@ -28,16 +28,6 @@ body {
   padding-bottom: 62px;
 }
 
-.sc {
-  font-variant: small-caps;
-  text-transform: lowercase;
-  display: inline-block;
-}
-
-.sc::first-letter {
-  text-transform: uppercase;
-}
-
 .reading-text {
   font-family: 'Merriweather', serif;
 }

--- a/apps/ds-vapi/package.json
+++ b/apps/ds-vapi/package.json
@@ -28,6 +28,6 @@
     "@types/node": "^17.0.5",
     "@types/sqlite3": "^3.1.8",
     "ts-node-dev": "^1.1.8",
-    "typescript": "^4.5.4"
+    "typescript": "^4.7.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/node": "^17.0.5",
         "@types/uuid": "^8.3.3",
         "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       }
     },
     "apps/ds-api/node_modules/dotenv": {
@@ -75,7 +75,7 @@
         "recharts": "^2.1.10",
         "remark-supersub": "^1.0.0",
         "sass": "^1.52.1",
-        "typescript": "^4.5.4",
+        "typescript": "^4.7.4",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
         "@types/node": "^17.0.5",
         "@types/sqlite3": "^3.1.8",
         "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       }
     },
     "apps/ds-vapi/node_modules/dotenv": {
@@ -22149,9 +22149,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23831,7 +23831,7 @@
         "@types/jest": "^27.4.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.3",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       }
     },
     "packages/refparse": {
@@ -23855,11 +23855,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@devouringscripture/common": "^1.0.0",
         "unified": "^10.1.2",
         "unist-util-visit": "^4.1.0"
       },
       "devDependencies": {
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       }
     },
     "packages/remark-plugins/node_modules/unist-util-visit": {
@@ -25276,13 +25277,14 @@
         "jest": "^27.5.1",
         "semver": "^7.3.5",
         "ts-jest": "^27.1.3",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       }
     },
     "@devouringscripture/remark-plugins": {
       "version": "file:packages/remark-plugins",
       "requires": {
-        "typescript": "^4.5.4",
+        "@devouringscripture/common": "^1.0.0",
+        "typescript": "^4.7.4",
         "unified": "^10.1.2",
         "unist-util-visit": "^4.1.0"
       },
@@ -29589,7 +29591,7 @@
         "luxon": "^2.4.0",
         "node-json-db": "^1.5.0",
         "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.4",
+        "typescript": "^4.7.4",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -29637,7 +29639,7 @@
         "recharts": "^2.1.10",
         "remark-supersub": "^1.0.0",
         "sass": "^1.52.1",
-        "typescript": "^4.5.4",
+        "typescript": "^4.7.4",
         "yup": "^0.32.11"
       },
       "dependencies": {
@@ -29707,7 +29709,7 @@
         "node-json-db": "^1.5.0",
         "sqlite3": "^5.0.8",
         "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.4",
+        "typescript": "^4.7.4",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -40200,9 +40202,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^27.4.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "build": "tsc --build",
@@ -32,10 +32,10 @@
   "author": "sernaferna",
   "license": "ISC",
   "dependencies": {
+    "bible-passage-reference-parser": "^2.0.1",
+    "bible-reference-formatter": "^1.0.1",
     "express": "^4.17.2",
     "express-validator": "^6.14.0",
-    "semver": "^7.3.5",
-    "bible-passage-reference-parser": "^2.0.1",
-    "bible-reference-formatter": "^1.0.1"
+    "semver": "^7.3.5"
   }
 }

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -6,7 +6,8 @@
   "types": "./build/index.d.ts",
   "dependencies": {
     "unified": "^10.1.2",
-    "unist-util-visit": "^4.1.0"
+    "unist-util-visit": "^4.1.0",
+    "@devouringscripture/common": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "^4.5.4"

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -5,12 +5,12 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "dependencies": {
+    "@devouringscripture/common": "^1.0.0",
     "unified": "^10.1.2",
-    "unist-util-visit": "^4.1.0",
-    "@devouringscripture/common": "^1.0.0"
+    "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {
-    "typescript": "^4.5.4"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "build": "tsc --build",

--- a/packages/remark-plugins/src/bible-links/index.ts
+++ b/packages/remark-plugins/src/bible-links/index.ts
@@ -16,6 +16,8 @@ export function bibleLinks(): Transformer {
 
       const { value } = node as Literal<string>;
 
+      console.debug(`initial value: ${value}`);
+
       const parseResult = bibleLinkRE.exec(value);
       if (parseResult === null) {
         return;
@@ -24,8 +26,11 @@ export function bibleLinks(): Transformer {
         return;
       }
 
-      let searchString = getFormattedReference(parseResult[1]);
-      searchString = encodeURIComponent(searchString);
+      console.debug(`Initial string: '${value.substring(0, parseResult.index)}'`);
+      console.debug(`string after the matched stuff: '${value.substring(parseResult.index + parseResult[0].length)}'`);
+
+      const formattedReference = getFormattedReference(parseResult[1]);
+      const searchString = encodeURIComponent(formattedReference);
 
       const linkUrl = `https://www.biblegateway.com/passage/?search=${searchString}&version=${parseResult[2]}`;
 
@@ -50,12 +55,24 @@ export function bibleLinks(): Transformer {
         children: [
           {
             type: 'text',
-            value: 'blah',
+            value: formattedReference,
           },
         ],
       };
 
-      parent.children.splice(i, 1, newLink);
+      const returnChildren = [
+        {
+          type: 'text',
+          value: value.substring(0, parseResult.index),
+        },
+        newLink,
+        {
+          type: 'text',
+          value: value.substring(parseResult.index + parseResult[0].length),
+        },
+      ];
+
+      parent.children.splice(i, 1, ...returnChildren);
     });
   };
 }

--- a/packages/remark-plugins/src/bible-links/index.ts
+++ b/packages/remark-plugins/src/bible-links/index.ts
@@ -3,7 +3,7 @@ import { visit } from 'unist-util-visit';
 import { Literal, Data, Node } from 'unist';
 import { isReferenceValid, getFormattedReference } from '@devouringscripture/common';
 
-const bibleLinkRE = /\[\[([^\]]*)\]([^\]]*)\]/;
+const bibleLinkRE = /\[\[([^\]]+)\]([^\]]*)\]/;
 const nivRE = /NIV/i;
 const esvRE = /ESV/i;
 
@@ -24,33 +24,26 @@ export function bibleLinks(): Transformer {
         return;
       }
 
+      const version = parseResult[2].length > 0 ? parseResult[2] : 'ESV';
+
       const formattedReference = getFormattedReference(parseResult[1]);
       const searchString = encodeURIComponent(formattedReference);
 
-      const linkUrl = `https://www.biblegateway.com/passage/?search=${searchString}&version=${parseResult[2]}`;
-
-      let linkClass = 'biblelink';
-      if (nivRE.test(parseResult[2])) {
-        linkClass = 'nivlink';
-      }
-      if (esvRE.test(parseResult[2])) {
-        linkClass = 'esvlink';
-      }
+      const linkUrl = `https://www.biblegateway.com/passage/?search=${searchString}&version=${version}`;
 
       const newLink = {
         type: 'link',
-        title: `${parseResult[1]} (${parseResult[2]})`,
+        title: `${parseResult[1]} (${version})`,
         url: linkUrl,
         data: {
           hProperties: {
-            className: [linkClass],
             target: '_blank',
           },
         },
         children: [
           {
             type: 'text',
-            value: formattedReference,
+            value: formattedReference + ` (${version})✞`,
           },
         ],
       };

--- a/packages/remark-plugins/src/bible-links/index.ts
+++ b/packages/remark-plugins/src/bible-links/index.ts
@@ -16,8 +16,6 @@ export function bibleLinks(): Transformer {
 
       const { value } = node as Literal<string>;
 
-      console.debug(`initial value: ${value}`);
-
       const parseResult = bibleLinkRE.exec(value);
       if (parseResult === null) {
         return;
@@ -25,9 +23,6 @@ export function bibleLinks(): Transformer {
       if (!isReferenceValid(parseResult[1])) {
         return;
       }
-
-      console.debug(`Initial string: '${value.substring(0, parseResult.index)}'`);
-      console.debug(`string after the matched stuff: '${value.substring(parseResult.index + parseResult[0].length)}'`);
 
       const formattedReference = getFormattedReference(parseResult[1]);
       const searchString = encodeURIComponent(formattedReference);

--- a/packages/remark-plugins/src/bible-links/index.ts
+++ b/packages/remark-plugins/src/bible-links/index.ts
@@ -1,0 +1,61 @@
+import { Transformer } from 'unified';
+import { visit } from 'unist-util-visit';
+import { Literal, Data, Node } from 'unist';
+import { isReferenceValid, getFormattedReference } from '@devouringscripture/common';
+
+const bibleLinkRE = /\[\[([^\]]*)\]([^\]]*)\]/;
+const nivRE = /NIV/i;
+const esvRE = /ESV/i;
+
+export function bibleLinks(): Transformer {
+  return (tree) => {
+    visit(tree, ['text'], (node, i, parent: any) => {
+      if (node.type !== 'text') {
+        return;
+      }
+
+      const { value } = node as Literal<string>;
+
+      const parseResult = bibleLinkRE.exec(value);
+      if (parseResult === null) {
+        return;
+      }
+      if (!isReferenceValid(parseResult[1])) {
+        return;
+      }
+
+      let searchString = getFormattedReference(parseResult[1]);
+      searchString = encodeURIComponent(searchString);
+
+      const linkUrl = `https://www.biblegateway.com/passage/?search=${searchString}&version=${parseResult[2]}`;
+
+      let linkClass = 'biblelink';
+      if (nivRE.test(parseResult[2])) {
+        linkClass = 'nivlink';
+      }
+      if (esvRE.test(parseResult[2])) {
+        linkClass = 'esvlink';
+      }
+
+      const newLink = {
+        type: 'link',
+        title: `${parseResult[1]} (${parseResult[2]})`,
+        url: linkUrl,
+        data: {
+          hProperties: {
+            className: [linkClass],
+            target: '_blank',
+          },
+        },
+        children: [
+          {
+            type: 'text',
+            value: 'blah',
+          },
+        ],
+      };
+
+      parent.children.splice(i, 1, newLink);
+    });
+  };
+}

--- a/packages/remark-plugins/src/index.ts
+++ b/packages/remark-plugins/src/index.ts
@@ -2,3 +2,4 @@ export * from './tac/index';
 export * from './lower-caps/index';
 export * from './small-caps/index';
 export * from './highlight/index';
+export * from './bible-links/index';

--- a/packages/remark-plugins/src/lower-caps/index.ts
+++ b/packages/remark-plugins/src/lower-caps/index.ts
@@ -27,7 +27,7 @@ export function lowerCaps(): Transformer {
               data: {
                 hName: 'span',
                 hProperties: {
-                  className: ['sc2'],
+                  style: 'font-variant: small-caps; text-transform: lowercase; display: inline-block;',
                 },
               },
               children: [

--- a/packages/remark-plugins/src/small-caps/index.ts
+++ b/packages/remark-plugins/src/small-caps/index.ts
@@ -23,11 +23,11 @@ export function smallCaps(): Transformer {
               value: str,
             }
           : {
-              type: 'span',
+              type: 'element',
               data: {
                 hName: 'span',
                 hProperties: {
-                  className: ['small-caps-style'],
+                  style: 'font-variant: small-caps;',
                 },
               },
               children: [

--- a/packages/remark-plugins/src/tac/index.ts
+++ b/packages/remark-plugins/src/tac/index.ts
@@ -16,28 +16,58 @@ export function tac(): Transformer {
         return;
       }
 
-      const children: Node<Data>[] = values.map((str, i) =>
-        i % 2 === 0
-          ? {
-              type: 'text',
-              value: str,
-            }
-          : {
-              type: 'span',
-              data: {
-                hName: 'span',
-                hProperties: {
-                  className: ['sc'],
-                },
+      const children: any[] = [];
+
+      values.forEach((item, index) => {
+        if (index % 2 === 0) {
+          children.push({
+            type: 'text',
+            value: item,
+          });
+          return;
+        }
+
+        const individualWords = item.split(' ');
+        individualWords.forEach((word, wordIndex) => {
+          children.push({
+            type: 'element',
+            data: {
+              hName: 'span',
+              hProperties: {
+                style: 'text-transform: uppercase;',
               },
-              children: [
-                {
-                  type: 'text',
-                  value: str,
-                },
-              ],
-            }
-      );
+            },
+            children: [
+              {
+                type: 'text',
+                value: word.substring(0, 1),
+              },
+            ],
+          });
+          children.push({
+            type: 'element',
+            data: {
+              hName: 'span',
+              hProperties: {
+                style: 'text-transform: lowercase; font-variant: small-caps;',
+              },
+            },
+            children: [
+              {
+                type: 'text',
+                value: word.substring(1, word.length),
+              },
+            ],
+          });
+
+          if (wordIndex <= individualWords.length) {
+            children.push({
+              type: 'text',
+              value: ' ',
+            });
+          }
+        });
+      });
 
       parent.children.splice(i, 1, ...children);
     });


### PR DESCRIPTION
Various changes to the way the application handles **markdown**, mostly in an effort to make exporting easier (i.e. not requiring external stylesheets to properly render things).

* Closes #213 (by updating typescript)
* Closes #214  for same
* Closes #211 to add special MD links for bible verses
* Closes #216 to inline CSS instead of relying on SASS/CSS classes
* Closes #212 to add some documentation into the README
* Closes #217 (via a hack) for cases where a version isn't supplied to the bible links