### PR TITLE
Markdown Changes

### DIFF
--- a/apps/ds-ui/src/components/common/MarkdownBox.tsx
+++ b/apps/ds-ui/src/components/common/MarkdownBox.tsx
@@ -1,123 +1,19 @@
-import React, { useState, useRef, useEffect } from 'react';
-import MDEditor, { ICommand, TextState, TextAreaTextApi } from '@uiw/react-md-editor';
-import { Button } from 'react-bootstrap';
-import supersub from 'remark-supersub';
-import { tac, lowerCaps, smallCaps, highlight, bibleLinks } from '@devouringscripture/remark-plugins';
+import React, { useState } from 'react';
+import MDEditor, { ICommand } from '@uiw/react-md-editor';
+import { Button, Modal } from 'react-bootstrap';
 import { MarkdownTutorial } from './MarkdownTutorial';
+import {
+  lordCommand,
+  esvLinkCommand,
+  nivLinkCommand,
+  bibleLinkCommand,
+  highlightCommand,
+  scCommand,
+  scstyleCommand,
+  superCommand,
+} from './md-helpers/md-commands';
+import { MarkdownPreview } from './md-helpers/MarkdownPreview';
 
-const MIN_SIZE_FOR_TOOLBAR = 450;
-
-interface IMarkdownPreview {
-  content: string;
-  shaded?: boolean;
-}
-export const MarkdownPreview = ({ content, shaded = true }: IMarkdownPreview) => {
-  const classNames: string = shaded ? 'bg-light border mx-1 my-2' : ';';
-  return (
-    <MDEditor.Markdown
-      source={content}
-      className={classNames}
-      remarkPlugins={[tac, lowerCaps, smallCaps, highlight, supersub, bibleLinks]}
-    />
-  );
-};
-
-const lordCommand: ICommand = {
-  name: 'LORD',
-  keyCommand: 'LORD',
-  buttonProps: { 'aria-label': 'Insert LORD' },
-  icon: (
-    <>
-      <b>L</b>
-      <b style={{ fontVariant: 'small-caps' }}>ord</b>
-    </>
-  ),
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `^^^${state.selectedText ? state.selectedText : 'LORD'}^^^`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const scCommand: ICommand = {
-  name: 'SC',
-  keyCommand: 'SC',
-  buttonProps: { 'aria-label': 'Insert all SMALL CAPS' },
-  icon: <b style={{ fontVariant: 'small-caps', textTransform: 'lowercase', display: 'inline-block' }}>A.D.</b>,
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `^^${state.selectedText ? state.selectedText : 'A.D.'}^^`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const scstyleCommand: ICommand = {
-  name: 'SmallCaps',
-  keyCommand: 'SmallCaps',
-  buttonProps: { 'aria-label': 'Insert Small Caps' },
-  icon: <span style={{ fontVariant: 'small-caps' }}>SmCa</span>,
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `^-^${state.selectedText}^-^`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const superCommand: ICommand = {
-  name: 'Superscript',
-  keyCommand: 'Superscript',
-  buttonProps: { 'aria-label': 'Superscript' },
-  icon: (
-    <b>
-      2<sup>2</sup>
-    </b>
-  ),
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `^${state.selectedText}^`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const highlightCommand: ICommand = {
-  name: 'Highlight',
-  keyCommand: 'Highlight',
-  buttonProps: { 'aria-label': 'Highlight' },
-  icon: <mark>abc</mark>,
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `==${state.selectedText}==`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const esvLinkCommand: ICommand = {
-  name: 'ESVLink',
-  keyCommand: 'ESVLink',
-  buttonProps: { 'aria-label': 'Bible link' },
-  icon: <u>ESV✞</u>,
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `[[${state.selectedText}]ESV]`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const nivLinkCommand: ICommand = {
-  name: 'NIVLink',
-  keyCommand: 'NIVLink',
-  buttonProps: { 'aria-label': 'Bible link' },
-  icon: <u>NIV✞</u>,
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `[[${state.selectedText}]NIV]`;
-    api.replaceSelection(modifyText);
-  },
-};
-
-const bibleLinkCommand: ICommand = {
-  name: 'BibleLink',
-  keyCommand: 'BibleLink',
-  buttonProps: { 'aria-label': 'Bible link' },
-  icon: <u>BG✞</u>,
-  execute: (state: TextState, api: TextAreaTextApi) => {
-    const modifyText = `[[${state.selectedText}]]`;
-    api.replaceSelection(modifyText);
-  },
-};
 const commandsToFilterOut = ['code', 'image', 'checked-list', 'hr', 'title2'];
 
 const commandsFilter = (command: ICommand<string>, isExtra: boolean) => {
@@ -139,28 +35,8 @@ interface IMarkdownBox {
 }
 export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IMarkdownBox) => {
   const [showPreviewState, setShowPreviewState] = useState(showPreview);
-  const mdContainer = useRef<HTMLDivElement>(null);
-  const [showToolbar, setShowToolbar] = useState<boolean>(false);
   const [showMDTutorial, setShowMDTutorial] = useState<boolean>(false);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (mdContainer === null || mdContainer.current === null) {
-        setShowToolbar(false);
-        return;
-      }
-
-      if (mdContainer.current!.offsetWidth > MIN_SIZE_FOR_TOOLBAR) {
-        setShowToolbar(true);
-        return;
-      }
-
-      setShowToolbar(false);
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-  }, [mdContainer, setShowToolbar]);
+  const [showFullScreen, setShowFullScreen] = useState<boolean>(false);
 
   const reversePreviewState = () => {
     return () => {
@@ -169,16 +45,13 @@ export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IM
   };
 
   const handleChangeEvent = (newValue: string | undefined) => {
-    if (newValue) {
-      changeCallback(newValue);
-    }
+    changeCallback(newValue || '');
   };
 
   return (
     <div>
-      <div ref={mdContainer} className="mb-2">
+      <div className="mb-2">
         <MDEditor
-          id="this-is-the-editor"
           value={content}
           onChange={handleChangeEvent}
           highlightEnable={true}
@@ -196,7 +69,7 @@ export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IM
           ]}
           visiableDragbar={false}
           commandsFilter={commandsFilter}
-          hideToolbar={!showToolbar}
+          hideToolbar={true}
         />
         <Button
           variant="link"
@@ -207,12 +80,9 @@ export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IM
         >
           Show Tutorial
         </Button>
-        <MarkdownTutorial
-          show={showMDTutorial}
-          handleClose={() => {
-            setShowMDTutorial(false);
-          }}
-        />
+        <Button variant="link" size="sm" onClick={() => setShowFullScreen(true)}>
+          Full Scren
+        </Button>
       </div>
       <div className="d-grid gap-2">
         <Button size="sm" variant="secondary" onClick={reversePreviewState()}>
@@ -220,6 +90,56 @@ export const MarkdownBox = ({ content, changeCallback, showPreview = false }: IM
         </Button>
         {showPreviewState ? <MarkdownPreview content={content} /> : <></>}
       </div>
+      <MarkdownTutorial
+        show={showMDTutorial}
+        handleClose={() => {
+          setShowMDTutorial(false);
+        }}
+      />
+      <Modal show={showFullScreen} fullscreen="md-down" size="lg" onHide={() => setShowFullScreen(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Edit</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="mb-2">
+            <MDEditor
+              value={content}
+              onChange={handleChangeEvent}
+              highlightEnable={true}
+              preview="edit"
+              defaultTabEnable={true}
+              extraCommands={[
+                lordCommand,
+                scCommand,
+                scstyleCommand,
+                esvLinkCommand,
+                nivLinkCommand,
+                bibleLinkCommand,
+                superCommand,
+                highlightCommand,
+              ]}
+              visiableDragbar={true}
+              commandsFilter={commandsFilter}
+              hideToolbar={false}
+            />
+            <Button
+              variant="link"
+              size="sm"
+              onClick={() => {
+                setShowMDTutorial(true);
+              }}
+            >
+              Show Tutorial
+            </Button>
+          </div>
+          <div className="d-grid gap-2">
+            <Button size="sm" variant="secondary" onClick={reversePreviewState()}>
+              {showPreviewState ? 'Hide Preview' : 'Show Preview'}
+            </Button>
+            {showPreviewState ? <MarkdownPreview content={content} /> : <></>}
+          </div>
+        </Modal.Body>
+      </Modal>
     </div>
   );
 };

--- a/apps/ds-ui/src/components/common/md-helpers/MarkdownPreview.tsx
+++ b/apps/ds-ui/src/components/common/md-helpers/MarkdownPreview.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import MDEditor from '@uiw/react-md-editor';
+import supersub from 'remark-supersub';
+import { tac, lowerCaps, smallCaps, highlight, bibleLinks } from '@devouringscripture/remark-plugins';
+
+interface IMarkdownPreview {
+  content: string;
+  shaded?: boolean;
+}
+export const MarkdownPreview = ({ content, shaded = true }: IMarkdownPreview) => {
+  const classNames: string = shaded ? 'bg-light border mx-1 my-2' : ';';
+  return (
+    <MDEditor.Markdown
+      source={content}
+      className={classNames}
+      remarkPlugins={[tac, lowerCaps, smallCaps, highlight, supersub, bibleLinks]}
+    />
+  );
+};

--- a/apps/ds-ui/src/components/common/md-helpers/md-commands.tsx
+++ b/apps/ds-ui/src/components/common/md-helpers/md-commands.tsx
@@ -1,0 +1,98 @@
+import { ICommand, TextState, TextAreaTextApi } from '@uiw/react-md-editor';
+
+export const lordCommand: ICommand = {
+  name: 'LORD',
+  keyCommand: 'LORD',
+  buttonProps: { 'aria-label': 'Insert LORD' },
+  icon: (
+    <>
+      <b>L</b>
+      <b style={{ fontVariant: 'small-caps' }}>ord</b>
+    </>
+  ),
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `^^^${state.selectedText ? state.selectedText : 'LORD'}^^^`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const scCommand: ICommand = {
+  name: 'SC',
+  keyCommand: 'SC',
+  buttonProps: { 'aria-label': 'Insert all SMALL CAPS' },
+  icon: <b style={{ fontVariant: 'small-caps', textTransform: 'lowercase', display: 'inline-block' }}>A.D.</b>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `^^${state.selectedText ? state.selectedText : 'A.D.'}^^`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const scstyleCommand: ICommand = {
+  name: 'SmallCaps',
+  keyCommand: 'SmallCaps',
+  buttonProps: { 'aria-label': 'Insert Small Caps' },
+  icon: <span style={{ fontVariant: 'small-caps' }}>SmCa</span>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `^-^${state.selectedText}^-^`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const superCommand: ICommand = {
+  name: 'Superscript',
+  keyCommand: 'Superscript',
+  buttonProps: { 'aria-label': 'Superscript' },
+  icon: (
+    <b>
+      2<sup>2</sup>
+    </b>
+  ),
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `^${state.selectedText}^`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const highlightCommand: ICommand = {
+  name: 'Highlight',
+  keyCommand: 'Highlight',
+  buttonProps: { 'aria-label': 'Highlight' },
+  icon: <mark>abc</mark>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `==${state.selectedText}==`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const esvLinkCommand: ICommand = {
+  name: 'ESVLink',
+  keyCommand: 'ESVLink',
+  buttonProps: { 'aria-label': 'Bible link' },
+  icon: <u>ESV✞</u>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `[[${state.selectedText}]ESV]`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const nivLinkCommand: ICommand = {
+  name: 'NIVLink',
+  keyCommand: 'NIVLink',
+  buttonProps: { 'aria-label': 'Bible link' },
+  icon: <u>NIV✞</u>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `[[${state.selectedText}]NIV]`;
+    api.replaceSelection(modifyText);
+  },
+};
+
+export const bibleLinkCommand: ICommand = {
+  name: 'BibleLink',
+  keyCommand: 'BibleLink',
+  buttonProps: { 'aria-label': 'Bible link' },
+  icon: <u>BG✞</u>,
+  execute: (state: TextState, api: TextAreaTextApi) => {
+    const modifyText = `[[${state.selectedText}]]`;
+    api.replaceSelection(modifyText);
+  },
+};

--- a/apps/ds-ui/src/components/prayer/PrayerCards.tsx
+++ b/apps/ds-ui/src/components/prayer/PrayerCards.tsx
@@ -15,7 +15,7 @@ import { ShieldPlus, Tsunami, EyeFill } from 'react-bootstrap-icons';
 import { useSelector } from 'react-redux';
 import { getPrayerViewFilter } from '../../stores/UISlice';
 import { paginateItems } from '../../helpers/pagination';
-import { MarkdownPreview } from '../common/MarkdownBox';
+import { MarkdownPreview } from '../common/md-helpers/MarkdownPreview';
 import { PrayerIconsContainer } from './PrayerIconsContainer';
 import { PlaceholderCard } from './PlaceholderCard';
 

--- a/apps/ds-ui/src/components/prayer/PrayerSnapshot.tsx
+++ b/apps/ds-ui/src/components/prayer/PrayerSnapshot.tsx
@@ -6,7 +6,7 @@ import { ErrorLoadingDataMessage } from '../common/loading';
 import { paginateItems } from '../../helpers/pagination';
 import { PrayerListItem, UserAttributes } from '@devouringscripture/common';
 import { getPrayerIcon } from './PrayerCards';
-import { MarkdownPreview } from '../common/MarkdownBox';
+import { MarkdownPreview } from '../common/md-helpers/MarkdownPreview';
 
 const PlaceholderList = () => {
   return (


### PR DESCRIPTION
Completes the following:

* Closes #221 to fix bug with deleting content from markdown box
* Closes #215 to have a pop-up UI with full, rich editing capabilities, vs. the inline version from which the toolbar has been stripped
* Closes #222 to refactor code out of the main md component