### PR TITLE
MINOR moved fs out of ds-ui and into modal in mde

### DIFF
--- a/apps/ds-ui/src/components/read/ReadPage.tsx
+++ b/apps/ds-ui/src/components/read/ReadPage.tsx
@@ -34,14 +34,6 @@ import { AllNotes } from './notes/AllNotes';
  */
 export const ReadPage = () => {
   const [userData, userResponseError, userLoading] = useUserSettings();
-  const [showMDFullScreen, setShowMDFullScreen] = useState<boolean>(false);
-
-  const switchMDFullScreen = useCallback(
-    (fs: boolean) => {
-      setShowMDFullScreen(fs);
-    },
-    [setShowMDFullScreen]
-  );
 
   if (userLoading) {
     return <LoadingMessage />;
@@ -57,23 +49,15 @@ export const ReadPage = () => {
       </Container>
       <Container fluid={true} className="page-main-container">
         <Row>
-          {!showMDFullScreen && (
-            <Col xs="12" lg="6">
-              <PassageCards sortOrder={userData!.settings.read.sortPassages} />
-            </Col>
-          )}
-          <Col xs="12" lg={showMDFullScreen ? '12' : '6'}>
-            <PassageNotes
-              setShowMDFullScreen={switchMDFullScreen}
-              showMDFullScreen={showMDFullScreen}
-              autosaveNotes={userData!.settings.read.autosavePassageNotes}
-            />
+          <Col xs="12" lg="6">
+            <PassageCards sortOrder={userData!.settings.read.sortPassages} />
           </Col>
-          {!showMDFullScreen && (
-            <Col xs="12">
-              <AllNotes />
-            </Col>
-          )}
+          <Col xs="12" lg="6">
+            <PassageNotes autosaveNotes={userData!.settings.read.autosavePassageNotes} />
+          </Col>
+          <Col xs="12">
+            <AllNotes />
+          </Col>
         </Row>
       </Container>
     </>

--- a/apps/ds-ui/src/components/read/notes/MDNoteTaker.tsx
+++ b/apps/ds-ui/src/components/read/notes/MDNoteTaker.tsx
@@ -62,8 +62,6 @@ const schema = yup.object({
 type ValuesSchema = yup.InferType<typeof schema>;
 
 interface IMDNoteTaker {
-  showMDFullScreen: boolean;
-  setShowMDFullScreen(fs: boolean): void;
   autosaveNotes: boolean;
 }
 
@@ -85,11 +83,9 @@ interface IMDNoteTaker {
  * * **ReadPage** includes **PassageNotes**
  * * PassageNotes displays *MDNoteTaker* and **NotesForPassage**
  *
- * @param showMDFullScreen Indicates if the MD editor should be shown full screen
- * @param setShowMDFullScreen Callback function to call when switching between full and non-full screen MD mode
  * @param autosaveNotes Indicates whether notes should be automatically saved every few seconds
  */
-export const MDNoteTaker = ({ showMDFullScreen, setShowMDFullScreen, autosaveNotes }: IMDNoteTaker) => {
+export const MDNoteTaker = ({ autosaveNotes }: IMDNoteTaker) => {
   const selectedPassageID = useSelector(getSelectedPassage);
   const selectedNoteID = useSelector(getSelectedNote);
   const {
@@ -112,16 +108,6 @@ export const MDNoteTaker = ({ showMDFullScreen, setShowMDFullScreen, autosaveNot
   const mdRef = useRef<HTMLDivElement>(null);
   const formikRef = useRef<FormikProps<ValuesSchema>>(null);
   const [timer, setTimer] = useState<NodeJS.Timer | null>(null);
-
-  const switchFS = useCallback(
-    (fs: boolean) => {
-      setShowMDFullScreen(fs);
-      if (mdRef.current) {
-        mdRef.current.scrollIntoView({ behavior: 'smooth' });
-      }
-    },
-    [setShowMDFullScreen]
-  );
 
   const downloadedNoteText = useMemo(() => {
     if (selectedNote && !noteIsLoading && selectedNoteID === selectedNote.id) {
@@ -170,7 +156,6 @@ export const MDNoteTaker = ({ showMDFullScreen, setShowMDFullScreen, autosaveNot
 
   const newNoteBtn = () => {
     dispatch(updateSelectedNote(''));
-    setShowMDFullScreen(false);
   };
 
   const formSubmit = useCallback(
@@ -337,9 +322,6 @@ export const MDNoteTaker = ({ showMDFullScreen, setShowMDFullScreen, autosaveNot
               }
             }}
             fullScreenOption={true}
-            showingFullScreen={showMDFullScreen}
-            setFullSreen={switchFS}
-            showSidePreview={showMDFullScreen ? true : false}
             height={10}
           />
           <div className="m-2 d-flex flex-row-reverse">

--- a/apps/ds-ui/src/components/read/notes/PassageNotes.tsx
+++ b/apps/ds-ui/src/components/read/notes/PassageNotes.tsx
@@ -9,8 +9,6 @@ import { useGetPassageByIdQuery } from '../../../services/PassagesService';
 import { v4 as uuidv4 } from 'uuid';
 
 interface IPassageNotes {
-  showMDFullScreen: boolean;
-  setShowMDFullScreen(fs: boolean): void;
   autosaveNotes: boolean;
 }
 
@@ -28,11 +26,9 @@ interface IPassageNotes {
  * * **ReadPage** includes *PassageNotes*
  * * *PassageNotes* displays **MDNoteTaker** and **NotesForPassage**
  *
- * @param showMDFullScreen Whether the MD editor should be shown full screen
- * @param setShowMDFullScreen Callback function to call when switching in/out of MD fullscreen
  * @param autosaveNotes Indicates whether notes should be autosaved (passthrough to `MDNoteTaker`)
  */
-export const PassageNotes = ({ showMDFullScreen, setShowMDFullScreen, autosaveNotes }: IPassageNotes) => {
+export const PassageNotes = ({ autosaveNotes }: IPassageNotes) => {
   const selectedPassageID = useSelector(getSelectedPassage);
   const selectedNoteID = useSelector(getSelectedNote);
   const { data, error, isLoading } = useGetPassageByIdQuery(selectedPassageID);
@@ -53,7 +49,7 @@ export const PassageNotes = ({ showMDFullScreen, setShowMDFullScreen, autosaveNo
     );
   }
 
-  const showNotesForPassage = selectedPassageID !== '' && !showMDFullScreen;
+  const showNotesForPassage = selectedPassageID !== '';
 
   return (
     <Row>
@@ -63,12 +59,7 @@ export const PassageNotes = ({ showMDFullScreen, setShowMDFullScreen, autosaveNo
         </Col>
       )}
       <Col xs="12" md={showNotesForPassage ? '6' : '12'} lg="12" xl={showNotesForPassage ? '7' : '12'}>
-        <MDNoteTaker
-          showMDFullScreen={showMDFullScreen}
-          setShowMDFullScreen={setShowMDFullScreen}
-          autosaveNotes={autosaveNotes}
-          key={selectedNoteID || uuidv4()}
-        />
+        <MDNoteTaker autosaveNotes={autosaveNotes} key={selectedNoteID || uuidv4()} />
       </Col>
     </Row>
   );

--- a/packages/mde/package.json
+++ b/packages/mde/package.json
@@ -68,5 +68,11 @@
     "@types/react-dom": {
       "optional": true
     }
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
   }
 }

--- a/packages/mde/src/components/helpers/FullScreenButton.tsx
+++ b/packages/mde/src/components/helpers/FullScreenButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
+interface IFullScreenButton {
+  isFullScreen: boolean;
+  stateSetter(fs: boolean): void;
+}
+export const FullScreenButton = ({ isFullScreen, stateSetter }: IFullScreenButton) => {
+  if (isFullScreen) {
+    return (
+      <Button variant="link" size="sm" onClick={() => stateSetter(false)}>
+        Show Normal View
+      </Button>
+    );
+  } else {
+    return (
+      <Button variant="link" size="sm" onClick={() => stateSetter(true)}>
+        Show Full Screen
+      </Button>
+    );
+  }
+};

--- a/packages/mde/tsconfig.json
+++ b/packages/mde/tsconfig.json
@@ -3,12 +3,7 @@
   "compilerOptions": {
     "outDir": "lib/esm",
     "jsx": "react",
-    "declaration": true,
-    "noUnusedLocals": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true
+    "declaration": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "lib"]


### PR DESCRIPTION
Moved MD full screen capabilities out of layout in ds-ui and as a model in the mde component instead.

Closes #434 